### PR TITLE
put a _ before numbered types

### DIFF
--- a/lib/gen/parser.js
+++ b/lib/gen/parser.js
@@ -75,6 +75,12 @@ export class JSONSchemaParser {
    */
   #buildInternalRef = (raw, templates = []) => {
     raw = this.#unresolveName(raw);
+
+    // Catch some cases where types start with a number.
+    if (raw.match(/^\d/)) {
+      raw = `_${raw}`;
+    }
+
     return new model.RefType(raw, true, templates);
   };
 
@@ -168,9 +174,14 @@ export class JSONSchemaParser {
    * @return {model.Property}
    */
   #parseProperty = (path, raw, overrideName, fallbackType) => {
-    const name = overrideName ?? raw.name ?? raw.id;
+    let name = overrideName ?? raw.name ?? raw.id;
     if (name === undefined) {
       throw new Error(`could not parse property, no name`);
+    }
+
+    // Fix invalid names that start with numbers.
+    if (name.match(/^\d/)) {
+      name = `_${name}`;
     }
 
     const extendedPath = extendPath(path, name);
@@ -426,12 +437,11 @@ export class JSONSchemaParser {
       }
 
       const prop = this.#parseProperty(path, f);
-      if (!f.id) {
+      if (!prop.name) {
         throw new Error(`type without id`);
       }
-      prop.name = f.id;
       prop.isType = true;
-      all[f.id] = prop;
+      all[prop.name] = prop;
     });
   
     const events = this.#parseRawEvents(path, raw.events);


### PR DESCRIPTION
The Chromium folks added a type that started with a number—which turns out is not valid to TypeScript.

Just mask it as it's only used for manifest keys. We don't have a way to filter manifest-only keys out though.