### PR TITLE
fix(usage): add `chrome` namespace to `Window` and add usage directions, fixes #17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ chrome-*.json
 .DS_Store
 node_modules/
 dist/*.d.ts
+!dist/global.d.ts
 dist/package.json
 .cache/
 coverage/

--- a/dist/README.md
+++ b/dist/README.md
@@ -1,5 +1,28 @@
+# chrome-types
 Published TypeScript definition files for Chrome Extensions, automatically generated from Chromium source code.
 
 The default types file "index.d.ts" contains MV3+ types only.
 
 The helper "_all.d.ts" contains types including the deprecated Platform Apps APIs, and is used for the developer.chrome.com site.
+
+## Set Up
+
+To expose the global `chrome` namespace be sure to include `chrome-types` in your `tsconfig.json`. You could add `"chrome-types"` to the `compilerOptions.types` array, though you will then need to include each type definitions you want. It is recommended that you add `"node_modules/chrome-types/global.d.ts"` to the `include` array instead.
+
+### `compilerOptions.types`
+
+```JSON
+{
+  "compilerOptions": {
+    "types": ["chrome-types"]
+  }
+}
+```
+
+### `include`
+
+```JSON
+{
+  "include": ["node_modules/chrome-types/global.d.ts"]
+}
+```

--- a/dist/global.d.ts
+++ b/dist/global.d.ts
@@ -1,0 +1,8 @@
+/// <reference name="chrome" types="./index" />
+
+interface Window {
+  /**
+   * Global Chrome namespace generated from Chromium source code.
+   */
+  chrome: typeof chrome;
+}

--- a/dist/package.template.json
+++ b/dist/package.template.json
@@ -15,5 +15,10 @@
   "bugs": {
     "url": "https://github.com/GoogleChrome/chrome-types/issues"
   },
-  "homepage": "https://github.com/GoogleChrome/chrome-types"
+  "homepage": "https://github.com/GoogleChrome/chrome-types",
+  "keywords": [
+    "chrome",
+    "chromium",
+    "types"
+  ]
 }


### PR DESCRIPTION
1. Add `dist/global.d.ts` which takes the build output and adds it to the Window interface.
2. Update `dist/README.md` to document how to include this lib into a projects global typings.
3. Tell `.gitignore` to include `dist/global.d.ts`.
4. Update `dist/package.template.json` with some keywords for search on npm.

[See this video for a little better explenation](https://www.loom.com/share/f3536b719ff14b0885d13fa771d7f2e2).  I also didn't want to modify any of the existing files so that we don't break the chrome types being used for dcc.