### PR TITLE
Correctly record history of returns_async return values.

### DIFF
--- a/tools/lib/render-context.js
+++ b/tools/lib/render-context.js
@@ -294,6 +294,11 @@ export class RenderContext {
 
       // Record all possible expansions, except void, which isn't rendered / does not exist.
       expansions.flat().forEach((param) => {
+        // If we already have a non-void return, don't overwrite with a void one
+        if (param.name === "return" && param.type === "void" && allParams.has("return")) {
+          return;
+        }
+        
         if (spec.type !== 'void') {
           allParams.set(param.name, param);
         }

--- a/tools/lib/traverse.js
+++ b/tools/lib/traverse.js
@@ -270,7 +270,7 @@ export class TraverseContext {
       // Ensure that there's a return type, or fall back to `void`.
       // Even if this has a name, we call it 'return'.
       const result = /** @type {chromeTypes.NamedTypeSpec[]} */ (work.filter((x) => x !== null));
-      const returns = spec.returns ?? { type: 'void' };
+      const returns = spec.returns ?? spec.returns_async ?? { type: 'void' };
       expansions.push([{ ...returns, name: 'return' }, ...result]);
     }
 


### PR DESCRIPTION
Prior to this change return values defined using the returns_async keyword did not properly appear in the history. This is because returns_async was not considered when creating the list of expansions.

Once this was added, there was a second issue because the old void/callback expansion was seen after the promise-based one and overwrote the history data we had generated. To avoid this I added logic which always prefers a return type over void.

Resolves #35 