### PR TITLE
Correctly determine channel for APIs with dependencies.

### DIFF
--- a/tools/lib/channel.js
+++ b/tools/lib/channel.js
@@ -49,3 +49,27 @@ export function mostReleasedChannel(a, b) {
     return b;
   }
 }
+
+/**
+ * Finds the channel that is furthest from 'stable'. If either param is `undefined`, returns the other.
+ *
+ * @param {chromeTypes.Channel | undefined} a
+ * @param {chromeTypes.Channel | undefined} b
+ * @return {chromeTypes.Channel | undefined}
+ */
+export function leastReleasedChannel(a, b) {
+  if (!a) {
+    return b;
+  } else if (!b) {
+    return a;
+  }
+
+  const indexA = channelOrdering.indexOf(a);
+  const indexB = channelOrdering.indexOf(b);
+
+  if (indexA > indexB) {
+    return a;
+  } else {
+    return b;
+  }
+}

--- a/tools/override.js
+++ b/tools/override.js
@@ -22,7 +22,7 @@
 
 import * as chromeTypes from '../types/chrome.js';
 import * as overrideTypes from '../types/override.js';
-import { mostReleasedChannel } from './lib/channel.js';
+import { leastReleasedChannel, mostReleasedChannel } from './lib/channel.js';
 import { buildNamespaceAwareMarkdownRewrite } from './lib/comment.js';
 import { FeatureQuery } from './lib/feature-query.js';
 import { namespaceNameFromId, parentId } from './lib/traverse.js';
@@ -446,7 +446,7 @@ export class RenderOverride extends EmptyRenderOverride {
     let bestChannel = undefined;
 
     this.#fq.checkFeature(id, (f, otherId) => {
-      bestChannel = mostReleasedChannel(bestChannel, f.channel);
+      bestChannel = leastReleasedChannel(bestChannel, f.channel);
     });
 
     return bestChannel ?? 'stable';


### PR DESCRIPTION
When considering dependencies, we were incorrectly choosing the "most released" channel as the channel an API became available. This was causing some issues as, for example, action.openPopup is still restricted to dev but it has a dependency of the action key in the manifest which has existed in stable for a while.

Fixing this should make the openPopup API correctly appear as restricted to dev, and also fix some other similar issues across the generated types.

I ran the tool and compared the generated types with the last published version of this package. There are only a dozen or so lines changed and the changes look reasonable, matching up to the versioning information I was able to find looking at when those APIs become available in the Chromium source.