### PR TITLE
Fix rendering of chrome.gcm senderIds type.

### DIFF
--- a/tests/lib/render-context.js
+++ b/tests/lib/render-context.js
@@ -159,3 +159,35 @@ test('override', t => {
 }`);
 
 });
+
+test('render minItems/maxItems with less than 10 values', t => {
+  const rc = new RenderContext(emptyOverride);
+
+  const out = rc.renderType({
+    "name": "senderIds",
+    "type": "array",
+    "items": {
+      "type": "string"
+    },
+    "minItems": 1,
+    "maxItems": 5,
+  }, '');
+
+  t.is(out, `[string] | [string, string] | [string, string, string] | [string, string, string, string] | [string, string, string, string, string]`);
+});
+
+test('render minItems/maxItems with more than 10 values', t => {
+  const rc = new RenderContext(emptyOverride);
+
+  const out = rc.renderType({
+    "name": "senderIds",
+    "type": "array",
+    "items": {
+      "type": "string"
+    },
+    "minItems": 1,
+    "maxItems": 100,
+  }, '');
+
+  t.is(out, `string[]`);
+});

--- a/tools/lib/render-context.js
+++ b/tools/lib/render-context.js
@@ -445,6 +445,14 @@ export class RenderContext {
 
       // There's a maximum number of items here. Render tuples from min -> max.
       if (spec.maxItems) {
+        // If there are more than 10 possibilities, we don't want to render
+        // [X] | [X, X] | [X, X, X] | [X, X, X, X] | [X, X, X, X, X]...
+        // so we instead just render X[] and rely on the docs to explain any
+        // limits (https://github.com/GoogleChrome/developer.chrome.com/issues/1850).
+        if (spec.maxItems - (spec.minItems ?? 0) > 10) {
+          return `${inner}[]`;
+        }
+
         /** @type {string[]} */
         const parts = [];
 


### PR DESCRIPTION
# Overview

Improves rendering of the chrome.gcm senderIds type in the chrome.gcm.register function.

| Old | New |
|-----|-----|
|  ![Screenshot 2023-06-07 at 11 01 39](https://github.com/GoogleChrome/chrome-types/assets/6097064/2cc6fa9c-88a6-4726-9652-8a64ba362aa7)  |   ![Screenshot 2023-06-07 at 11 00 44](https://github.com/GoogleChrome/chrome-types/assets/6097064/e754198c-1e92-4f55-b376-100c66be2ef2)  |

# Thought Process

When generating the chrome.gcm docs, we were previously seeing the following in the [gcm.json](https://source.chromium.org/chromium/chromium/src/+/main:chrome/common/extensions/api/gcm.json) spec:

```
{
  "name": "senderIds",
  "type": "array",
  "items": {
    "type": "string",
    "minLength": 1
  },
  "minItems": 1,
  "maxItems": 100,
},
```

And generating a union of all possible array lengths.

While it would be nice to have proper rendering for this in the future (e.g a min and max length tag) this PR implements a temporary solution where we simply collapse the type to X[] when we see more than 10 (an arbitrary but reasonable sound number) possible types. This seems reasonable since chrome.gcm is currently the only API with this problem (I checked) and the comments already explain the limit in detail.

# Additional Details

Fixes https://github.com/GoogleChrome/developer.chrome.com/issues/1850
Fixes https://github.com/GoogleChrome/developer.chrome.com/issues/5176