### PR TITLE
Fix incorrect nodoc in sidePanel.setPanelBehavior / sidePanel.getPanelBehavior method

### DIFF
--- a/tests/lib/override.js
+++ b/tests/lib/override.js
@@ -1,0 +1,15 @@
+import test from 'ava';
+import { RenderOverride } from '../../tools/override.js';
+import { FeatureQuery } from '../../tools/lib/feature-query.js';
+
+test('setPanelBehavior is visible', t => {
+  const rc = new RenderOverride({}, new FeatureQuery({}), {
+    generated: "",
+    high: 2,
+    low: 1,
+    revision: 0,
+    symbols: {}
+  });
+
+  t.assert(rc.isVisible({ nodoc: true }, 'api:sidePanel.setPanelBehavior'));
+});

--- a/tools/override.js
+++ b/tools/override.js
@@ -143,6 +143,8 @@ export class RenderOverride extends EmptyRenderOverride {
     switch (id) {
       case 'api:contextMenus.OnClickData':
       case 'api:notifications.NotificationBitmap':
+      case 'api:sidePanel.getPanelBehavior':
+      case 'api:sidePanel.setPanelBehavior':
         // In old versions of Chrome, this is incorrectly marked nodoc.
         return true;
     }


### PR DESCRIPTION
These APIs launched in Chrome 114 but were accidentally left as nodoc until 115: https://chromiumdash.appspot.com/commit/7a7c1a0c724483e5edae10f9ec45efec55c633e8

This will make sure they don't show as pending: https://developer.chrome.com/docs/extensions/reference/sidePanel/#method-setPanelBehavior

This adds them to a list of exceptions to make sure we generate the correct version information.