### PR TITLE
Ignore nodoc for getDisabledRuleIds and updateStaticRules methods

### DIFF
--- a/tools/override.js
+++ b/tools/override.js
@@ -145,6 +145,8 @@ export class RenderOverride extends EmptyRenderOverride {
       case 'api:notifications.NotificationBitmap':
       case 'api:sidePanel.getPanelBehavior':
       case 'api:sidePanel.setPanelBehavior':
+      case 'api:declarativeNetRequest.getDisabledRuleIds':
+      case 'api:declarativeNetRequest.updateStaticRules':
         // In old versions of Chrome, this is incorrectly marked nodoc.
         return true;
     }


### PR DESCRIPTION
These were marked as nodoc for a while, so ignoring that to get the correct version information in our docs.