### PR TITLE
Add flag for APIs that require policy install

### DIFF
--- a/tests/lib/feature-query.js
+++ b/tests/lib/feature-query.js
@@ -1,0 +1,26 @@
+import test from 'ava';
+import { FeatureQuery } from '../../tools/lib/feature-query.js';
+
+test('most stable channel is preferred', (t) => {
+  const featureQuery = new FeatureQuery({});
+
+  t.deepEqual(
+    featureQuery.mergeComplexFeature([
+      { channel: 'beta' },
+      { channel: 'stable', location: 'policy' },
+    ]),
+    { channel: 'stable', location: 'policy' }
+  );
+});
+
+test('extension features are preferred', (t) => {
+  const featureQuery = new FeatureQuery({});
+
+  t.deepEqual(
+    featureQuery.mergeComplexFeature([
+      { channel: 'stable', extension_types: ['hosted_app'] },
+      { channel: 'stable', min_manifest_version: 3, extension_types: ['extension'] }
+    ]),
+    { channel: 'stable', min_manifest_version: 3, extension_types: ['extension'] }
+  );
+});

--- a/tests/lib/override.js
+++ b/tests/lib/override.js
@@ -13,3 +13,22 @@ test('setPanelBehavior is visible', t => {
 
   t.assert(rc.isVisible({ nodoc: true }, 'api:sidePanel.setPanelBehavior'));
 });
+
+test('chrome-install-location tag is added', (t) => {
+  const rc = new RenderOverride({}, new FeatureQuery({'api:sidePanel.setPanelBehavior': { location: 'policy' }}), {
+    generated: "",
+    high: 2,
+    low: 1,
+    revision: 0,
+    symbols: {
+      'api:sidePanel.setPanelBehavior': {
+        high: 2
+      }
+    }
+  });
+
+  t.deepEqual(
+    rc.completeTagsFor({ id: 'api:sidePanel.setPanelBehavior' }, 'api:sidePanel.setPanelBehavior'),
+    [{ name: 'chrome-install-location', value: 'policy' }]
+  );
+});

--- a/tools/lib/feature-query.js
+++ b/tools/lib/feature-query.js
@@ -18,6 +18,7 @@
 import * as chromeTypes from '../../types/chrome.js';
 import { parentId } from './traverse.js';
 import { isDeepEqual } from './equal.js';
+import { mostReleasedChannel } from './channel.js';
 
 
 export class FeatureQuery {
@@ -57,6 +58,19 @@ export class FeatureQuery {
         ...first,
         dependencies: [...mergedDependencies],
       };
+    }
+
+    // Filter (potentially) by channel. Choose the most released channel (e.g., 'stable' over 'beta').
+    const bestChannel = q.reduce((channel, spec) => mostReleasedChannel(channel, spec.channel), /** @type {chromeTypes.Channel | undefined} */(undefined));
+    const bestChannelFilter = q.filter(({ channel }) => channel === bestChannel);
+    if (bestChannelFilter.length === 1) {
+      return bestChannelFilter[0];
+    }
+
+    // Filter by extension (prefer).
+    const extensionFilter = q.filter(({ extension_types }) => extension_types?.includes('extension'));
+    if (extensionFilter.length === 1) {
+      return extensionFilter[0];
     }
 
     // Features that are unclear here will throw.

--- a/tools/override.js
+++ b/tools/override.js
@@ -491,7 +491,7 @@ export class RenderOverride extends EmptyRenderOverride {
         isOnlyPlatformApps = true;
       }
 
-      requiresPolicyInstall = requiresPolicyInstall || (isDeepEqual(f.location, ['policy']));
+      requiresPolicyInstall = requiresPolicyInstall || (isDeepEqual(f.location, 'policy'));
     });
 
     const bestChannel = this.bestChannelFor(id);

--- a/tools/override.js
+++ b/tools/override.js
@@ -26,34 +26,7 @@ import { leastReleasedChannel, mostReleasedChannel } from './lib/channel.js';
 import { buildNamespaceAwareMarkdownRewrite } from './lib/comment.js';
 import { FeatureQuery } from './lib/feature-query.js';
 import { namespaceNameFromId, parentId } from './lib/traverse.js';
-
-
-export class FeatureQueryAll extends FeatureQuery {
-
-  /**
-   * @param {chromeTypes.FeatureSpec[]} q
-   * @return {chromeTypes.FeatureSpec | null | void}
-   */
-  mergeComplexFeature(q) {
-    const s = super.mergeComplexFeature(q);
-    if (s !== undefined) {
-      return s;
-    }
-
-    // Filter (potentially) by channel. Choose the most released channel (e.g., 'stable' over 'beta').
-    const bestChannel = q.reduce((channel, spec) => mostReleasedChannel(channel, spec.channel), /** @type {chromeTypes.Channel | undefined} */(undefined));
-    const bestChannelFilter = q.filter(({ channel }) => channel === bestChannel);
-    if (bestChannelFilter.length === 1) {
-      return bestChannelFilter[0];
-    }
-
-    // Filter by extension (prefer).
-    const extensionFilter = q.filter(({ extension_types }) => extension_types?.includes('extension'));
-    if (extensionFilter.length === 1) {
-      return extensionFilter[0];
-    }
-  }
-}
+import { isDeepEqual } from './lib/equal.js';
 
 
 /**
@@ -487,6 +460,9 @@ export class RenderOverride extends EmptyRenderOverride {
     /** @type {boolean} */
     let isOnlyPlatformApps = false;
 
+    /** @type {boolean} */
+    let requiresPolicyInstall = false;
+
     // Actually loop over all features.
     // Note that this generates an OR: e.g., accessibilityFeatures requires _either_
     // "permission:accessibilityFeatures.read" OR "permission:accessibilityFeatures.write", and we
@@ -514,6 +490,8 @@ export class RenderOverride extends EmptyRenderOverride {
       if (f.extension_types && !f.extension_types.includes('extension') && f.extension_types.includes('platform_app')) {
         isOnlyPlatformApps = true;
       }
+
+      requiresPolicyInstall = requiresPolicyInstall || (isDeepEqual(f.location, ['policy']));
     });
 
     const bestChannel = this.bestChannelFor(id);
@@ -525,6 +503,10 @@ export class RenderOverride extends EmptyRenderOverride {
     } else {
       tags.push({ name: 'chrome-channel', value: bestChannel });
       tags.unshift({ name: 'alpha' });
+    }
+
+    if (requiresPolicyInstall) {
+      tags.push({ name: 'chrome-install-location', value: 'policy' });
     }
 
     if (isOnlyPlatformApps) {

--- a/tools/render-symbols.js
+++ b/tools/render-symbols.js
@@ -28,7 +28,8 @@ import getStdin from 'get-stdin';
 import * as chromeTypes from '../types/chrome.js';
 import mri from 'mri';
 import { RenderContext } from './lib/render-context.js';
-import { FeatureQueryAll, RenderOverride } from './override.js';
+import { RenderOverride } from './override.js';
+import { FeatureQuery } from './lib/feature-query.js';
 import log from 'fancy-log';
 
 
@@ -57,7 +58,7 @@ This is used internally to generate historic version data for Chrome's APIs.
   /** @type {chromeTypes.ProcessedAPIData} */
   const o = JSON.parse(await getStdin());
 
-  const fq = new FeatureQueryAll(o.feature);
+  const fq = new FeatureQuery(o.feature);
   const renderOverride = new RenderOverride(o.api, fq);
   const renderContext = new RenderContext(renderOverride);
 

--- a/tools/render-symbols.js
+++ b/tools/render-symbols.js
@@ -58,8 +58,8 @@ This is used internally to generate historic version data for Chrome's APIs.
   /** @type {chromeTypes.ProcessedAPIData} */
   const o = JSON.parse(await getStdin());
 
-  const fq = new FeatureQuery(o.feature);
-  const renderOverride = new RenderOverride(o.api, fq);
+  const featureQuery = new FeatureQuery(o.feature);
+  const renderOverride = new RenderOverride(o.api, featureQuery);
   const renderContext = new RenderContext(renderOverride);
 
   /** @type {Map<string, boolean>} */

--- a/tools/render-tsd.js
+++ b/tools/render-tsd.js
@@ -93,16 +93,16 @@ Options:
 // Built at ${o.definitionsRevision}${versionSuffix}`);
 
   /** @type {FeatureQuery} */
-  let fq;
+  let featureQuery;
 
   if (argv.all) {
     // We include all APIs, MV2 and MV3 etc, to render on the site.
-    fq = new FeatureQuery(o.feature);
+    featureQuery = new FeatureQuery(o.feature);
 
     renderParts.push(`// Includes all types, including MV2 + Platform Apps APIs.`);
 
   } else {
-    fq = new FeatureQueryModern(o.feature);
+    featureQuery = new FeatureQueryModern(o.feature);
 
     renderParts.push(`// Includes MV3+ APIs only.`);
 
@@ -113,7 +113,7 @@ Options:
   const preambleFile = new URL('../content/preamble.d.ts', import.meta.url);
   renderParts.push(fs.readFileSync(preambleFile, 'utf-8'));
 
-  const renderOverride = new RenderOverride(o.api, fq, history);
+  const renderOverride = new RenderOverride(o.api, featureQuery, history);
   const renderContext = new RenderContext(renderOverride);
 
   // Render the .d.ts.

--- a/tools/render-tsd.js
+++ b/tools/render-tsd.js
@@ -28,7 +28,7 @@ import mri from 'mri';
 import { RenderContext } from './lib/render-context.js';
 import { FeatureQuery } from './lib/feature-query.js';
 import log from 'fancy-log';
-import { FeatureQueryAll, RenderOverride } from './override.js';
+import { RenderOverride } from './override.js';
 
 
 async function run() {
@@ -97,7 +97,7 @@ Options:
 
   if (argv.all) {
     // We include all APIs, MV2 and MV3 etc, to render on the site.
-    fq = new FeatureQueryAll(o.feature);
+    fq = new FeatureQuery(o.feature);
 
     renderParts.push(`// Includes all types, including MV2 + Platform Apps APIs.`);
 

--- a/types/chrome.d.ts
+++ b/types/chrome.d.ts
@@ -43,6 +43,7 @@ export type Context = 'blessed_extension' | 'blessed_web_page' | 'content_script
 export type ExtensionType = 'extension' | 'hosted_app' | 'legacy_packaged_app' | 'platform_app' | 'shared_module' | 'theme' | 'login_screen_extension';
 export type All = 'all';
 export type SessionType = 'regular' | 'kiosk' | 'kiosk.autolaunched';
+export type Location = 'component' | 'external_component' | 'policy' | 'unpacked';
 
 
 export interface FeatureSpec {


### PR DESCRIPTION
We recently launched openPopup on stable but only for policy installed extensions: https://source.chromium.org/chromium/chromium/src/+/main:chrome/common/extensions/api/_api_features.json;l=76;drc=49b6f6844aa33f8f940a59fd00f9281b8b6ebd9b

This adds the necessary data to the types to render the following on developer.chrome.com (we'll need a second PR which I'll open shortly):

<img width="457" alt="Screenshot 2023-10-11 at 16 29 21" src="https://github.com/GoogleChrome/chrome-types/assets/6097064/d1714001-d5fc-4f4d-965e-20c517204395">

There was a small bit of refactoring here, namely deleting `FeatureQueryAll`. It extended `FeatureQuery` but `FeatureQuery` was never used anywhere, so the extra class was unnecessary.