### PR TITLE
Ignore nodoc for MAX_NUMBER_OF_DYNAMIC_RULES

### DIFF
--- a/tests/lib/override.js
+++ b/tests/lib/override.js
@@ -32,3 +32,27 @@ test('chrome-install-location tag is added', (t) => {
     [{ name: 'chrome-install-location', value: 'policy' }]
   );
 });
+
+test('pending shown for added and removed type', (t) => {
+  const id = 'api:declarativeNetRequest.MAX_NUMBER_OF_DYNAMIC_RULES';
+  const rc = new RenderOverride({}, new FeatureQuery({}), {
+    generated: "",
+    // Newest release is Chrome 5.
+    high: 5,
+    low: 1,
+    revision: 0,
+    symbols: {
+      [id]: {
+        // But this symbol was last seen in Chrome 2.
+        high: 2
+      }
+    },
+  });
+
+  // Check that if we saw this in the source, it would show as Pending (since
+  // it will be available again from Chrome 6 onwards).
+  t.deepEqual(
+    rc.sinceTextFor({ id }, id),
+    { since: 'Missing 2 vs 5' }
+  );
+});

--- a/tools/override.js
+++ b/tools/override.js
@@ -576,8 +576,9 @@ export class RenderOverride extends EmptyRenderOverride {
       return { since: 'Pending' };
 
     } else if (self.high < this.#history.high) {
-      // This symbol is missing?
-      // TODO: This should never happen.
+      // A symbol is present now, has some history (so it isn't new) but wasn't
+      // in the last stable release. This means it was temporarily removed and
+      // then later added back in a higher version.
       return { since: `Missing ${self.high} vs ${this.#history.high}` };
 
     }

--- a/tools/override.js
+++ b/tools/override.js
@@ -120,6 +120,7 @@ export class RenderOverride extends EmptyRenderOverride {
       case 'api:sidePanel.setPanelBehavior':
       case 'api:declarativeNetRequest.getDisabledRuleIds':
       case 'api:declarativeNetRequest.updateStaticRules':
+      case 'api:declarativeNetRequest.MAX_NUMBER_OF_DYNAMIC_RULES':
         // In old versions of Chrome, this is incorrectly marked nodoc.
         return true;
     }


### PR DESCRIPTION
In the [chrome.declarativeNetRequest](https://developer.chrome.com/docs/extensions/reference/declarativeNetRequest/#property-MAX_NUMBER_OF_DYNAMIC_RULES) types, we are showing an unhelpful output for `MAX_NUMBER_OF_DYNAMIC_RULES`:

<img width="514" alt="Screenshot 2023-11-16 at 11 25 20" src="https://github.com/GoogleChrome/chrome-types/assets/6097064/0484dad4-3e52-4388-ad3a-1347cc7ae6c7">

This has actually been present for many Chrome versions but when we added session rules, we [added nodoc](https://chromium-review.googlesource.com/c/chromium/src/+/2612481) thinking we would remove it in a future version.

As part of implementing safe rules, however, we're bringing it back. This confused chrome-types since it essentially went missing for a while.

There are two commits here:

- The first is the actual fix and just ignores the nodoc.
- The second is adding some comments and a test for a "this should never be hit" section of code that I got an understanding of as part of investigating this. It isn't really needed, but I had already written it before I realised that so felt worth committing.