### PR TITLE
Use updated API endpoint and compatible compiler version for IDL files

### DIFF
--- a/tools/lib/chrome-versions.js
+++ b/tools/lib/chrome-versions.js
@@ -37,7 +37,7 @@ const tagPrefix = 'refs/tags/';
 const repoUrl = 'https://chromium.googlesource.com/chromium/src.git';
 
 
-const omahaProxyUrl = 'https://omahaproxy.appspot.com/all.json';
+const versionHistoryUrl = 'https://versionhistory.googleapis.com/v1/chrome/platforms/all/channels/stable/versions/';
 
 
 /**
@@ -136,24 +136,18 @@ export async function chromeVersions() {
 
 
 /**
- * Fetches and finds the current stable version of Chrome via omahaproxy.
+ * Fetches and finds the current stable version of Chrome.
  *
  * @return {Promise<number>}
  */
 export async function chromePublishedStable() {
-  const r = await fetch(omahaProxyUrl);
-  const data = /** @type {chromeTypes.OmahaProxyData} */ (await r.json());
+  const r = await fetch(versionHistoryUrl);
+  const data = /** @type {chromeTypes.VersionHistoryData} */ (await r.json());
 
-  for (const row of data) {
-    for (const version of row.versions) {
-      if (version.channel !== 'stable') {
-        continue;
-      }
-
-      const numericRelease = +version.version.split('.')[0];
-      if (numericRelease) {
-        return numericRelease;
-      }
+  for (const version of data.versions) {
+    const numericRelease = +version.version.split('.')[0];
+    if (numericRelease) {
+      return numericRelease;
     }
   }
 

--- a/tools/prepare.js
+++ b/tools/prepare.js
@@ -61,15 +61,23 @@ const toolsPaths = [
 
 /**
  * @param {{
+ *   majorChrome: number | undefined,
  *   workPath: string,
  *   headRevision: string,
  *   definitionsRevision: string,
  *   cpuLimit: number,
  * }} opts
  */
-async function prepareInTemp({ workPath, headRevision, definitionsRevision, cpuLimit }) {
+async function prepareInTemp({ majorChrome, workPath, headRevision, definitionsRevision, cpuLimit }) {
+  // In Chrome 121, IDL files were changed to use promises for methods by
+  // default. In older versions, we want to use the tool from the last commit
+  // before this change was made.
+  const toolRevision = typeof majorChrome === "number" && majorChrome < 121
+    ? "c279767649d882b71a14697fe9935d3c890a1ec7"
+    : headRevision;
+
   const defitionsPromise = fetchAllTo(workPath, definitionPaths, definitionsRevision);
-  const toolsPromise = fetchAllTo(workPath, toolsPaths, headRevision);
+  const toolsPromise = fetchAllTo(workPath, toolsPaths, toolRevision);
   const definitionsFiles = (await defitionsPromise).flatMap(cand => cand ?? []);
   const toolsFiles = (await toolsPromise).flatMap(cand => cand ?? []);
 
@@ -195,10 +203,11 @@ Options:
   const versions = await chromeVersions();
   const headRevision = versions.head;
 
+  const majorChrome = hasChromeVersion ? Math.ceil(+argv._[0]) : undefined;
+
   /** @type {string} */
   let definitionsRevision;
-  if (hasChromeVersion) {
-    const majorChrome = Math.ceil(+argv._[0]);
+  if (typeof majorChrome === "number") {
     versionData = versions.releases.get(majorChrome) ?? null;
     if (!versionData) {
       throw new Error(`unknown Chrome version: ${argv._[0]}`);
@@ -224,6 +233,7 @@ Options:
   let out;
   try {
     out = await prepareInTemp({
+      majorChrome,
       headRevision,
       definitionsRevision,
       workPath,

--- a/types/chrome.d.ts
+++ b/types/chrome.d.ts
@@ -211,15 +211,12 @@ export type SpecCallback = (spec: TypeSpec, id: string) => void;
 export type Tag = { name: string, value?: string };
 
 
-export type OmahaProxyData = {
-  os: string,
+export type VersionHistoryData = {
   versions: {
-    channel: Channel,
+    name: string,
     version: string,
-    current_reldate: string,
-    branch_commit: string,
   }[],
-}[];
+};
 
 
 /**


### PR DESCRIPTION
This fixes two issues which arose with the chrome-types workflow over the holidays:

- Omaha Proxy was taken offline (https://groups.google.com/a/chromium.org/g/chromium-dev/c/uH-nFrOLWtE). As a result, I have updated the tool to use the recommended replacement API endpoint for determining the most recent Chrome version.
- In [this commit](https://source.chromium.org/chromium/chromium/src/+/4d69e3840fbb82b93651c2be152d9bba5c453bbf), a breaking change was made to the format of our IDL files. Consequently, using the latest version of the tool no longer works on IDL files from before Chrome 121. I have changed the tool to use an older version in these cases.