### PR TITLE
Ignore nodoc on runtime userscript methods

### DIFF
--- a/tools/override.js
+++ b/tools/override.js
@@ -121,6 +121,8 @@ export class RenderOverride extends EmptyRenderOverride {
       case 'api:declarativeNetRequest.getDisabledRuleIds':
       case 'api:declarativeNetRequest.updateStaticRules':
       case 'api:declarativeNetRequest.MAX_NUMBER_OF_DYNAMIC_RULES':
+      case 'api:runtime.onUserScriptConnect':
+      case 'api:runtime.onUserScriptMessage':
         // In old versions of Chrome, this is incorrectly marked nodoc.
         return true;
     }


### PR DESCRIPTION
These were incorrectly marked as nodoc in the Chromium source code which means the version information generated for them was wrong.