### PR TITLE
Set up chrome-types for upcoming schema changes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "chrome-types",
+  "name": "chrome-types-schema-change",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -32,7 +32,7 @@
         "check-code-coverage": "^1.10.0"
       },
       "engines": {
-        "node": "16"
+        "node": ">=16"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "chrome-types-schema-change",
+  "name": "chrome-types",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -32,7 +32,7 @@
         "check-code-coverage": "^1.10.0"
       },
       "engines": {
-        "node": ">=16"
+        "node": "16"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/tests/lib/traverse.js
+++ b/tests/lib/traverse.js
@@ -152,38 +152,6 @@ test('expandFunctionParams returns', t => {
 
 });
 
-test('expandFunctionParams returns_async does_not_support_promises', t => {
-  const filter = () => true;
-  const tc = new traverse.TraverseContext(filter);
-
-  /** @type {chromeTypes.TypeSpec} */
-  const returnsAsyncFunction = {
-    type: 'function',
-    parameters: [
-      { type: 'string', name: 's' },
-    ],
-    returns_async: {
-      name: 'callback',
-      type: 'function',
-      does_not_support_promises: 'For testing',
-      parameters: [{ type: 'number', name: 'whatever' }],
-    },
-  };
-
-  const returnsAsyncFunctionExpansions = tc.expandFunctionParams(
-    cloneObject(returnsAsyncFunction),
-    'api:test',
-  );
-  // Since this does not support promises, we expect to only get the callback signature.
-  t.deepEqual(returnsAsyncFunctionExpansions, [
-    [
-      { type: 'void', name: 'return' },
-      { type: 'string', name: 's' },
-      expectedOptionalReturnsAsync,
-    ]
-  ]);
-});
-
 test('expandFunctionParams returns_async', t => {
   const filter = () => true;
   const tc = new traverse.TraverseContext(filter);
@@ -228,7 +196,37 @@ test('expandFunctionParams returns_async', t => {
   ]);
 });
 
+test('expandFunctionParams returns_async does_not_support_promises', t => {
+  const filter = () => true;
+  const tc = new traverse.TraverseContext(filter);
 
+  /** @type {chromeTypes.TypeSpec} */
+  const returnsAsyncFunction = {
+    type: 'function',
+    parameters: [
+      { type: 'string', name: 's' },
+    ],
+    returns_async: {
+      name: 'callback',
+      type: 'function',
+      does_not_support_promises: 'For testing',
+      parameters: [{ type: 'number', name: 'whatever' }],
+    },
+  };
+
+  const returnsAsyncFunctionExpansions = tc.expandFunctionParams(
+    cloneObject(returnsAsyncFunction),
+    'api:test',
+  );
+  // Since this does not support promises, we expect to only get the callback signature.
+  t.deepEqual(returnsAsyncFunctionExpansions, [
+    [
+      { type: 'void', name: 'return' },
+      { type: 'string', name: 's' },
+      { ...returnsAsyncFunction.returns_async },
+    ]
+  ]);
+});
 
 test('filter', t => {
   /** @type {(spec: chromeTypes.TypeSpec, id: string) => boolean} */

--- a/tests/lib/traverse.js
+++ b/tests/lib/traverse.js
@@ -152,6 +152,37 @@ test('expandFunctionParams returns', t => {
 
 });
 
+test('expandFunctionParams returns_async does_not_support_promises', t => {
+  const filter = () => true;
+  const tc = new traverse.TraverseContext(filter);
+
+  /** @type {chromeTypes.TypeSpec} */
+  const returnsAsyncFunction = {
+    type: 'function',
+    parameters: [
+      { type: 'string', name: 's' },
+    ],
+    returns_async: {
+      name: 'callback',
+      type: 'function',
+      does_not_support_promises: 'For testing',
+      parameters: [{ type: 'number', name: 'whatever' }],
+    },
+  };
+
+  const returnsAsyncFunctionExpansions = tc.expandFunctionParams(
+    cloneObject(returnsAsyncFunction),
+    'api:test',
+  );
+  // Since this does not support promises, we expect to only get the callback signature.
+  t.deepEqual(returnsAsyncFunctionExpansions, [
+    [
+      { type: 'void', name: 'return' },
+      { type: 'string', name: 's' },
+      expectedOptionalReturnsAsync,
+    ]
+  ]);
+});
 
 test('expandFunctionParams returns_async', t => {
   const filter = () => true;
@@ -196,6 +227,7 @@ test('expandFunctionParams returns_async', t => {
     ]
   ]);
 });
+
 
 
 test('filter', t => {

--- a/tools/lib/traverse.js
+++ b/tools/lib/traverse.js
@@ -219,17 +219,18 @@ export class TraverseContext {
    * @return {[chromeTypes.NamedTypeSpec, ...chromeTypes.NamedTypeSpec[]][]}
    */
   expandFunctionParams(spec, id) {
-    // If this function uses "returns_asyc", expand it out and call ourselves again to generate
-    // the valid signatures (either just callback or Promise and callback).
+    if (!spec) {
+      return [];
+    }
+
+    // If this function uses "returns_async", expand it out and call ourselves again to generate
+    // the valid signatures for both Promise and callback versions. Note: a few  functions with
+    // asynchronous returns don't support a promise version, in which case withPromise is
+    // undefined here and will return an empty array (handled just above this).
     const expanded = this._maybeExpandFunctionReturnsAsync(spec);
     if (expanded) {
-      if (expanded.withPromise && expanded.withCallback) {
-        return [
-          ...this.expandFunctionParams(expanded.withPromise, id),
-          ...this.expandFunctionParams(expanded.withCallback, id),
-        ];
-      }
       return [
+        ...this.expandFunctionParams(expanded.withPromise, id),
         ...this.expandFunctionParams(expanded.withCallback, id),
       ];
     }

--- a/tools/lib/traverse.js
+++ b/tools/lib/traverse.js
@@ -146,6 +146,24 @@ export class TraverseContext {
     if (!returns_async) {
       return undefined;
     }
+
+    /** @type {chromeTypes.TypeSpec} */
+    let callbackParameter = {
+      ...returns_async,
+      type: 'function',
+    };
+    // If this signature doesn't support promises we just convert the "returns_async" field to a
+    // callback.
+    if (returns_async.does_not_support_promises) {
+      return {
+        withCallback: {
+          ...clone,
+          parameters: [...spec.parameters ?? [], callbackParameter],
+        },
+      };
+    }
+
+    // Otherwise this is a promise signature, so we can do a few checks to make sure it is valid.
     if (spec.returns) {
       throw new Error(`got returns_async and returns on function spec: ${JSON.stringify(spec)}`);
     }
@@ -168,15 +186,8 @@ export class TraverseContext {
       };
     }
 
-    // We convert the "returns_async" field to a callback (it has all the same values).
-    // Force it to be optional: by definition if it's omitted then we'll have a Promise-returning
-    // version. This isn't done correctly in the source.
-    /** @type {chromeTypes.TypeSpec} */
-    const callbackParameter = {
-      ...returns_async,
-      type: 'function',
-      optional: true,
-    };
+    // For promise supporting functions, the callback in inheriently optional, so we force that here.
+    callbackParameter.optional = true;
 
     return {
       withPromise: {
@@ -198,7 +209,7 @@ export class TraverseContext {
 
   /**
    * Chrome supports "early" optional parameters, as well as a special "returns_async" parameter
-   * which actually means that this returns a `Promise` OR supports a callback.
+   * which actually means that this API may return a `Promise` OR supports a callback.
    *
    * This expands all possible combinations for rendering as multiple signatures. The return type
    * includes the signature's return in the 0th position, followed by all parameters.
@@ -208,12 +219,17 @@ export class TraverseContext {
    * @return {[chromeTypes.NamedTypeSpec, ...chromeTypes.NamedTypeSpec[]][]}
    */
   expandFunctionParams(spec, id) {
-    // If this is actually a Promise-supporting API, then we call ourselves again to support both
-    // callback and Promise-based versions.
+    // If this function uses "returns_asyc", expand it out and call ourselves again to generate
+    // the valid signatures (either just callback or Promise and callback).
     const expanded = this._maybeExpandFunctionReturnsAsync(spec);
     if (expanded) {
+      if (expanded.withPromise && expanded.withCallback) {
+        return [
+          ...this.expandFunctionParams(expanded.withPromise, id),
+          ...this.expandFunctionParams(expanded.withCallback, id),
+        ];
+      }
       return [
-        ...this.expandFunctionParams(expanded.withPromise, id),
         ...this.expandFunctionParams(expanded.withCallback, id),
       ];
     }

--- a/types/chrome.d.ts
+++ b/types/chrome.d.ts
@@ -156,6 +156,9 @@ export interface TypeSpec extends SharedSpec {
   // only for top-level namespace types
   noinline_doc?: boolean | 'True';
 
+  // only for returns_async types
+  does_not_support_promises?: string;
+
   // special to mark converted-from-event-to-property, not part of definition
   _event?: boolean;
 }


### PR DESCRIPTION
There's an upcoming schema change on the Chromium side which will flip all asynchronous returns to be defined using the "returns_async" field, instead of only for Promise-supporting functions. Previously this repo used the presence of the "returns_async" field as an indicator of promise support, but with the upcoming schema changes we instead need to look for the "does_not_support_promises" property on the "returns_async" field.

This pull request adds in support for looking for this new property and only returning the callback signature if it is there, while also remaining backwards compatible with the older form so the change can happen cleanly.