### PR TITLE
Ignore incorrect nodoc in Chrome 111+ for `world` parameter

### DIFF
--- a/tests/lib/override.js
+++ b/tests/lib/override.js
@@ -14,6 +14,16 @@ test('setPanelBehavior is visible', t => {
   t.assert(rc.isVisible({ nodoc: true }, 'api:sidePanel.setPanelBehavior'));
 });
 
+test('version specific API is visible in correct versions', t => {
+  // Correctly marked as nodoc in Chrome 110. Should not be visible.
+  const rcNotVisible = new RenderOverride({}, new FeatureQuery({}), null, 110);
+  t.assert(!rcNotVisible.isVisible({ nodoc: true }, 'api:extensionTypes.ExecutionWorld'));
+
+  // Incorrectly marked as nodoc in Chrome 111. nodoc should be ignored.
+  const rcVisible = new RenderOverride({}, new FeatureQuery({}), null, 111);
+  t.assert(rcVisible.isVisible({ nodoc: true }, 'api:extensionTypes.ExecutionWorld'));
+});
+
 test('chrome-install-location tag is added', (t) => {
   const rc = new RenderOverride({}, new FeatureQuery({'api:sidePanel.setPanelBehavior': { location: 'policy' }}), {
     generated: "",

--- a/tools/override.js
+++ b/tools/override.js
@@ -76,19 +76,22 @@ export class RenderOverride extends EmptyRenderOverride {
   #fq;
   #api;
   #history;
+  #majorVersion;
 
   /**
    * @param {{[name: string]: chromeTypes.NamespaceSpec}} api
    * @param {FeatureQuery} fq
    * @param {chromeTypes.HistoricSymbolsPayload?} history
+   * @param {number?} majorVersion
    */
-  constructor(api, fq, history = null) {
+  constructor(api, fq, history = null, majorVersion = null) {
     super();
     const allNamespaceNames = Object.keys(api);
     this.#commentRewriter = buildNamespaceAwareMarkdownRewrite(allNamespaceNames);
     this.#fq = fq;
     this.#api = api;
     this.#history = history;
+    this.#majorVersion = majorVersion;
   }
 
   /**
@@ -114,6 +117,9 @@ export class RenderOverride extends EmptyRenderOverride {
     }
 
     switch (id) {
+      case 'api:extensionTypes.ExecutionWorld':
+      case 'api:contentScripts.ContentScript.world':
+        return !this.#majorVersion || this.#majorVersion >= 111;
       case 'api:contextMenus.OnClickData':
       case 'api:notifications.NotificationBitmap':
       case 'api:sidePanel.getPanelBehavior':

--- a/tools/render-symbols.js
+++ b/tools/render-symbols.js
@@ -58,8 +58,10 @@ This is used internally to generate historic version data for Chrome's APIs.
   /** @type {chromeTypes.ProcessedAPIData} */
   const o = JSON.parse(await getStdin());
 
+  const majorVersion = o.version ? Math.ceil(+o.version.version.split(".")[0]) : undefined;
+
   const featureQuery = new FeatureQuery(o.feature);
-  const renderOverride = new RenderOverride(o.api, featureQuery);
+  const renderOverride = new RenderOverride(o.api, featureQuery, null, majorVersion);
   const renderContext = new RenderContext(renderOverride);
 
   /** @type {Map<string, boolean>} */


### PR DESCRIPTION
This type was added in [Chrome 102](https://chromiumdash.appspot.com/commit/e5ad3451c17b21341b0b9019b074801c44c92c9f) and implemented in [Chrome 111](https://chromiumdash.appspot.com/commit/8f07eaff87947a2e93214de2695de8052119180b). However, it is still marked as nodoc.

I have opened a [CL](https://chromium-review.googlesource.com/c/chromium/src/+/5563323) to remove the nodoc but we need to manually fix the versioning information.