### PR TITLE
Hide iconVariants namespace

### DIFF
--- a/tools/override.js
+++ b/tools/override.js
@@ -134,6 +134,10 @@ export class RenderOverride extends EmptyRenderOverride {
       case 'api:runtime.onUserScriptMessage':
         // In old versions of Chrome, this is incorrectly marked nodoc.
         return true;
+      case 'api:iconVariants':
+        // This is not marked as nodoc, but this is a non-shipping feature so
+        // doesn't make sense in our docs.
+        return false;
     }
     return !spec.nodoc;
   }


### PR DESCRIPTION
This is for a non-shipping feature and doesn't make sense to expose in the types package or our documentation.