### PR TITLE
Adjust visibility for action.openPopup API

### DIFF
--- a/tools/override.js
+++ b/tools/override.js
@@ -120,6 +120,8 @@ export class RenderOverride extends EmptyRenderOverride {
       case 'api:extensionTypes.ExecutionWorld':
       case 'api:contentScripts.ContentScript.world':
         return !this.#majorVersion || this.#majorVersion >= 111;
+      case 'api:action.openPopup':
+        return !this.#majorVersion || this.#majorVersion >= 126;
       case 'api:contextMenus.OnClickData':
       case 'api:notifications.NotificationBitmap':
       case 'api:sidePanel.getPanelBehavior':


### PR DESCRIPTION
This API was available for policy installed extensions in earlier versions of Chrome. However, hide the API in these versions when calculating history data. This means it will show as 127+ in our documentation, rather than 118+.

I'm going to open a corresponding Chromium CL so we also have a string documenting the policy availability in earlier versions.