### PR TITLE
Prefer features without `location` condition

### DIFF
--- a/tests/lib/feature-query.js
+++ b/tests/lib/feature-query.js
@@ -24,3 +24,15 @@ test('extension features are preferred', (t) => {
     { channel: 'stable', min_manifest_version: 3, extension_types: ['extension'] }
   );
 });
+
+test('non-location specific features are preferred', (t) => {
+  const featureQuery = new FeatureQuery({});
+
+  t.deepEqual(
+    featureQuery.mergeComplexFeature([
+      { channel: 'stable', feature_flag: 'my_feature_flag' },
+      { channel: 'stable', location: 'policy' }
+    ]),
+    { channel: 'stable', feature_flag: 'my_feature_flag' }
+  );
+});

--- a/tools/lib/feature-query.js
+++ b/tools/lib/feature-query.js
@@ -73,6 +73,13 @@ export class FeatureQuery {
       return extensionFilter[0];
     }
 
+    // If the availability differs based on install location, use the default
+    // (non policy / component extension) data.
+    const locationFilter = q.filter(({ location }) => !location);
+    if (locationFilter.length === 1) {
+      return locationFilter[0];
+    }
+
     // Features that are unclear here will throw.
   }
 


### PR DESCRIPTION
I originally had this change in https://github.com/GoogleChrome/chrome-types/pull/73, but then I thought it wasn't needed any more so removed it. Unfortunately the build is still failing and this should hopefully fix that: https://github.com/GoogleChrome/chrome-types/actions/runs/9392019690/job/25865438994#step:6:13862