### PR TITLE
Fix permissions for management API

### DIFF
--- a/tools/lib/feature-query.js
+++ b/tools/lib/feature-query.js
@@ -62,7 +62,9 @@ export class FeatureQuery {
 
     // Filter (potentially) by channel. Choose the most released channel (e.g., 'stable' over 'beta').
     const bestChannel = q.reduce((channel, spec) => mostReleasedChannel(channel, spec.channel ?? "stable"), /** @type {chromeTypes.Channel | undefined} */(undefined));
-    const bestChannelFilter = q.filter(({ channel }) => channel === bestChannel || (bestChannel === "stable" && typeof channel === "undefined"));
+    const bestChannelFilter = q.filter(({ channel }) => {
+      return channel === bestChannel || (bestChannel === "stable" && !channel);
+    });
     if (bestChannelFilter.length === 1) {
       return bestChannelFilter[0];
     }

--- a/tools/lib/feature-query.js
+++ b/tools/lib/feature-query.js
@@ -61,8 +61,8 @@ export class FeatureQuery {
     }
 
     // Filter (potentially) by channel. Choose the most released channel (e.g., 'stable' over 'beta').
-    const bestChannel = q.reduce((channel, spec) => mostReleasedChannel(channel, spec.channel), /** @type {chromeTypes.Channel | undefined} */(undefined));
-    const bestChannelFilter = q.filter(({ channel }) => channel === bestChannel);
+    const bestChannel = q.reduce((channel, spec) => mostReleasedChannel(channel, spec.channel ?? "stable"), /** @type {chromeTypes.Channel | undefined} */(undefined));
+    const bestChannelFilter = q.filter(({ channel }) => channel === bestChannel || (bestChannel === "stable" && typeof channel === "undefined"));
     if (bestChannelFilter.length === 1) {
       return bestChannelFilter[0];
     }
@@ -241,6 +241,13 @@ function basicFilter(f) {
     if (!ok) {
       return false;
     }
+  }
+
+  // An API only exposed to "web_page" contexts (such as the APIs exposed to
+  // the Chrome Web Store) are unlikely to be ones we want to show in the
+  // documentation.
+  if (f.contexts?.length === 1 && f.contexts[0] === "web_page") {
+    return false;
   }
 
   return true;


### PR DESCRIPTION
A recent Chromium change [1] exposed the management API to the Chrome Web Store for testing purposes. Unfortunately, this meant chrome-types was thinking that the API was available without the `management` permission.

Unfortunately, I couldn't see an easy way to fix this.

To resolve that, I've made two tweaks here as workarounds:

1) Ignore feature definitions that are only for webpages. We don't really ever have a reason to show those in our documentation.

2) Teach the tool that if no channel is specified, this is equivalent to an API being available on stable.

Together, these seem to be enough to cause the tool to filter out the wrong definitions and pick up the ones used by most developers.

[1] https://source.chromium.org/chromium/chromium/src/+/59d0c94348743ce1831a113b81fd5dc420d68919:extensions/common/api/_api_features.json;dlc=30d48f6ef398e61601b43bcea809ac846fb99535