### PR TITLE
Exclude internal experimentalAiData namespace

### DIFF
--- a/tools/override.js
+++ b/tools/override.js
@@ -137,6 +137,7 @@ export class RenderOverride extends EmptyRenderOverride {
         // In old versions of Chrome, this is incorrectly marked nodoc.
         return true;
       case 'api:iconVariants':
+      case 'api:experimentalAiData':
         // This is not marked as nodoc, but this is a non-shipping feature so
         // doesn't make sense in our docs.
         return false;


### PR DESCRIPTION
This namespace is not a public API, but was being added to our docs as it doesn't follow the normal naming convention of including internal or private in the namespace (e.g chrome.developerPrivate).