### PR TITLE
Fix promise availability for storage API

### DIFF
--- a/tests/lib/traverse.js
+++ b/tests/lib/traverse.js
@@ -178,8 +178,9 @@ test('expandFunctionParams returns_async', t => {
   const returnsAsyncFunctionExpansions = tc.expandFunctionParams(
     cloneObject(returnsAsyncFunction),
     'api:test',
+    true
   );
-  t.deepEqual(returnsAsyncFunctionExpansions, [
+  t.deepEqual([
     [
       {
         $ref: 'Promise',
@@ -193,7 +194,7 @@ test('expandFunctionParams returns_async', t => {
       { type: 'string', name: 's' },
       expectedOptionalReturnsAsync,
     ]
-  ]);
+  ], returnsAsyncFunctionExpansions);
 });
 
 test('expandFunctionParams returns_async does_not_support_promises', t => {

--- a/tools/lib/render-context.js
+++ b/tools/lib/render-context.js
@@ -290,7 +290,7 @@ export class RenderContext {
 
     // Don't invoke symbol callbacks while we render this, because there's many possible expansions.
     this.#skipCallbacks(() => {
-      const expansions = this.#t.expandFunctionParams(spec, id);
+      const expansions = this.#t.expandFunctionParams(spec, id, this.#override.isPromiseSupportVisible(spec, id));
 
       // Record all possible expansions, except void, which isn't rendered / does not exist.
       expansions.flat().forEach((param) => {

--- a/tools/lib/traverse.js
+++ b/tools/lib/traverse.js
@@ -136,13 +136,13 @@ export class TraverseContext {
 
   /**
    * @param {chromeTypes.TypeSpec} spec of the function which itself has returns_async
-   * @param {boolean} promiseSupportVisible If we should hide the promise return type
+   * @param {boolean} isPromiseSupportVisible If we should hide the promise return type
    * @return {{
    *   withPromise: chromeTypes.TypeSpec,
    *   withCallback: chromeTypes.TypeSpec,
    * }=}
    */
-  _maybeExpandFunctionReturnsAsync(spec, promiseSupportVisible) {
+  _maybeExpandFunctionReturnsAsync(spec, isPromiseSupportVisible) {
     const { returns_async, ...clone } = spec;
     if (!returns_async) {
       return undefined;
@@ -156,7 +156,7 @@ export class TraverseContext {
 
     // If this signature doesn't support promises, or promise support is hidden
     // in this version, we just convert the "returns_async" field to a callback.
-    if (returns_async.does_not_support_promises || !promiseSupportVisible) {
+    if (returns_async.does_not_support_promises || !isPromiseSupportVisible) {
       return {
         withCallback: {
           ...clone,
@@ -218,10 +218,10 @@ export class TraverseContext {
    *
    * @param {chromeTypes.TypeSpec} spec
    * @param {string} id
-   * @param {boolean} promiseSupportVisible If we should hide the promise return type
+   * @param {boolean} isPromiseSupportVisible If we should hide the promise return type
    * @return {[chromeTypes.NamedTypeSpec, ...chromeTypes.NamedTypeSpec[]][]}
    */
-  expandFunctionParams(spec, id, promiseSupportVisible) {
+  expandFunctionParams(spec, id, isPromiseSupportVisible) {
     if (!spec) {
       return [];
     }
@@ -230,11 +230,11 @@ export class TraverseContext {
     // the valid signatures for both Promise and callback versions. Note: a few  functions with
     // asynchronous returns don't support a promise version, in which case withPromise is
     // undefined here and will return an empty array (handled just above this).
-    const expanded = this._maybeExpandFunctionReturnsAsync(spec, promiseSupportVisible);
+    const expanded = this._maybeExpandFunctionReturnsAsync(spec, isPromiseSupportVisible);
     if (expanded) {
       return [
-        ...this.expandFunctionParams(expanded.withPromise, id, promiseSupportVisible),
-        ...this.expandFunctionParams(expanded.withCallback, id, promiseSupportVisible),
+        ...this.expandFunctionParams(expanded.withPromise, id, isPromiseSupportVisible),
+        ...this.expandFunctionParams(expanded.withCallback, id, isPromiseSupportVisible),
       ];
     }
 

--- a/tools/lib/traverse.js
+++ b/tools/lib/traverse.js
@@ -136,12 +136,13 @@ export class TraverseContext {
 
   /**
    * @param {chromeTypes.TypeSpec} spec of the function which itself has returns_async
+   * @param {boolean} promiseSupportVisible If we should hide the promise return type
    * @return {{
    *   withPromise: chromeTypes.TypeSpec,
    *   withCallback: chromeTypes.TypeSpec,
    * }=}
    */
-  _maybeExpandFunctionReturnsAsync(spec) {
+  _maybeExpandFunctionReturnsAsync(spec, promiseSupportVisible) {
     const { returns_async, ...clone } = spec;
     if (!returns_async) {
       return undefined;
@@ -152,9 +153,10 @@ export class TraverseContext {
       ...returns_async,
       type: 'function',
     };
-    // If this signature doesn't support promises we just convert the "returns_async" field to a
-    // callback.
-    if (returns_async.does_not_support_promises) {
+
+    // If this signature doesn't support promises, or promise support is hidden
+    // in this version, we just convert the "returns_async" field to a callback.
+    if (returns_async.does_not_support_promises || !promiseSupportVisible) {
       return {
         withCallback: {
           ...clone,
@@ -216,9 +218,10 @@ export class TraverseContext {
    *
    * @param {chromeTypes.TypeSpec} spec
    * @param {string} id
+   * @param {boolean} promiseSupportVisible If we should hide the promise return type
    * @return {[chromeTypes.NamedTypeSpec, ...chromeTypes.NamedTypeSpec[]][]}
    */
-  expandFunctionParams(spec, id) {
+  expandFunctionParams(spec, id, promiseSupportVisible) {
     if (!spec) {
       return [];
     }
@@ -227,11 +230,11 @@ export class TraverseContext {
     // the valid signatures for both Promise and callback versions. Note: a few  functions with
     // asynchronous returns don't support a promise version, in which case withPromise is
     // undefined here and will return an empty array (handled just above this).
-    const expanded = this._maybeExpandFunctionReturnsAsync(spec);
+    const expanded = this._maybeExpandFunctionReturnsAsync(spec, promiseSupportVisible);
     if (expanded) {
       return [
-        ...this.expandFunctionParams(expanded.withPromise, id),
-        ...this.expandFunctionParams(expanded.withCallback, id),
+        ...this.expandFunctionParams(expanded.withPromise, id, promiseSupportVisible),
+        ...this.expandFunctionParams(expanded.withCallback, id, promiseSupportVisible),
       ];
     }
 

--- a/tools/lib/traverse.js
+++ b/tools/lib/traverse.js
@@ -136,7 +136,7 @@ export class TraverseContext {
 
   /**
    * @param {chromeTypes.TypeSpec} spec of the function which itself has returns_async
-   * @param {boolean} isPromiseSupportVisible If we should hide the promise return type
+   * @param {boolean} isPromiseSupportVisible If we should show the promise return type
    * @return {{
    *   withPromise: chromeTypes.TypeSpec,
    *   withCallback: chromeTypes.TypeSpec,
@@ -218,7 +218,7 @@ export class TraverseContext {
    *
    * @param {chromeTypes.TypeSpec} spec
    * @param {string} id
-   * @param {boolean} isPromiseSupportVisible If we should hide the promise return type
+   * @param {boolean} isPromiseSupportVisible If we should show the promise return type
    * @return {[chromeTypes.NamedTypeSpec, ...chromeTypes.NamedTypeSpec[]][]}
    */
   expandFunctionParams(spec, id, isPromiseSupportVisible) {

--- a/tools/override.js
+++ b/tools/override.js
@@ -40,6 +40,10 @@ export class EmptyRenderOverride {
     return true;
   }
 
+  isPromiseSupportVisible(spec, id) {
+    return true;
+  }
+
   /**
    * @return {string | undefined}
    */
@@ -143,6 +147,25 @@ export class RenderOverride extends EmptyRenderOverride {
         return false;
     }
     return !spec.nodoc;
+  }
+
+  /**
+   * @param {chromeTypes.TypeSpec} spec
+   * @param {string} id
+   */
+  isPromiseSupportVisible(spec, id) {
+    switch (id) {
+      case 'api:storage.StorageArea.get':
+      case 'api:storage.StorageArea.set':
+      case 'api:storage.StorageArea.remove':
+      case 'api:storage.StorageArea.clear':
+      case 'api:storage.StorageArea.getBytesInUse':
+        // We added and then reverted a commit to land promise support in 88.
+        // The commit which eventually shipped to land this was in Chrome 95.
+        return !this.#majorVersion || this.#majorVersion >= 95;
+      default:
+        return true;
+    }
   }
 
   /**

--- a/types/override.d.ts
+++ b/types/override.d.ts
@@ -29,6 +29,11 @@ export interface RenderOverride {
   isVisible(spec: chromeTypes.TypeSpec, id: string): boolean;
 
   /**
+   * Should we show the fact that this method supports promises?
+   */
+  isPromiseSupportVisible(spec: chromeTypes.TypeSpec, id: string): boolean;
+
+  /**
    * These are the template overrides for interface definitions within Chrome's extensions codebase.
    *
    * Chrome has no way of specifying that a type might be templated, so this can't upgrade a passed


### PR DESCRIPTION
We began to add promise support for the storage API in Chrome 88 [1], but this was reverted and we didn't finish implementation until Chrome 95 [2]. This caused some issues with our version detection.

I'm not a huge fan of the approach here, but this felt like a good balance between a hardcoded exception in the actual generation code and not overengineering something for this one case.

[1] https://chromiumdash.appspot.com/commit/84869dc2d4381fe85fd71d5f41289de26caeb406
[2] https://chromiumdash.appspot.com/commit/4300dde73a5036bee8d7c00944fda7e8dc5df8d4