### PR TITLE
Disable compression to reduce CI failures

### DIFF
--- a/tools/lib/chrome-source.js
+++ b/tools/lib/chrome-source.js
@@ -79,7 +79,7 @@ export async function fetchAllTo(targetPath, chromePaths, revision) {
 export async function fetchTo(targetPath, chromePath, revision) {
   const url = urlFor(revision, chromePath);
 
-  const r = await fetch(url);
+  const r = await fetch(url, { compress: false });
   if (!r.ok) {
     // HACK: Old platform_apps folder is missing. Skip for now.
     if (r.status === 400 && chromePath === 'chrome/common/apps/platform_apps/api') {


### PR DESCRIPTION
There have been a number of recent CI failures [1] which are related to zlib compression when downloading files from the Chromium repository. This may be an unrelated issue (e.g throttling / network instability) but disabling compression to see if it helps. I was able to get at least one CI pass using this [2].

[1] https://github.com/GoogleChrome/chrome-types/actions/runs/15348275531
[2] https://github.com/GoogleChrome/chrome-types/actions/runs/15348791346